### PR TITLE
Add root view to unify design system and UX helpers

### DIFF
--- a/ChiuGaDevKit/ChiuGaDevKit.swift
+++ b/ChiuGaDevKit/ChiuGaDevKit.swift
@@ -5,5 +5,32 @@
 //  Created by Chiu on 2025/8/20.
 //
 
-import Foundation
+import SwiftUI
+
+/// A convenience root view that wires up the design system and
+/// common UX helpers such as theming and toast presentation.
+public struct CGDKRoot<Content: View>: View {
+    @StateObject private var themeManager: CGDKThemeManager
+    @StateObject private var toastCenter = CGDKToastCenter()
+    private let content: () -> Content
+
+    /// Creates a root container.
+    /// - Parameters:
+    ///   - theme: Initial theme to apply. Defaults to ``CGDKTheme.default``.
+    ///   - content: The view hierarchy that should adopt the standard style.
+    public init(theme: CGDKTheme = .default, @ViewBuilder content: @escaping () -> Content) {
+        _themeManager = StateObject(wrappedValue: CGDKThemeManager(theme: theme))
+        self.content = content
+    }
+
+    public var body: some View {
+        CGDKToastHost(center: toastCenter) {
+            content()
+                .environmentObject(themeManager)
+                .environmentObject(toastCenter)
+                .cgdkThemedBackground()
+                .cgdkAppStyle()
+        }
+    }
+}
 

--- a/ChiuGaDevKit/DemoPreview/DemoView.swift
+++ b/ChiuGaDevKit/DemoPreview/DemoView.swift
@@ -8,35 +8,36 @@
 import SwiftUI
 
 public struct CGDKDemoView: View {
-    @StateObject var theme = CGDKThemeManager()
-    @StateObject var toast = CGDKToastCenter()
     public init() {}
     public var body: some View {
-        CGDKToastHost(center: toast) {
-            ScrollView {
-                CGDKSectionHeader("ChiuGaDevKit", sub: "Design System")
-                VStack(spacing: CGDKTokens.Space.lg) {
-                    CGDKCard {
-                        VStack(alignment: .leading, spacing: CGDKTokens.Space.sm) {
-                            Text("統一設計系統").font(CGDKTokens.Font.title())
-                            Text("這是 Card + Tokens + Theme 的示範。")
-                                .foregroundStyle(CGDKTokens.Color.muted)
-                        }
+        CGDKRoot {
+            DemoContent()
+        }
+    }
+}
+
+private struct DemoContent: View {
+    @EnvironmentObject var toast: CGDKToastCenter
+    var body: some View {
+        ScrollView {
+            CGDKSectionHeader("ChiuGaDevKit", sub: "Design System")
+            VStack(spacing: CGDKTokens.Space.lg) {
+                CGDKCard {
+                    VStack(alignment: .leading, spacing: CGDKTokens.Space.sm) {
+                        Text("統一設計系統").font(CGDKTokens.Font.title())
+                        Text("這是 Card + Tokens + Theme 的示範。")
+                            .foregroundStyle(CGDKTokens.Color.muted)
                     }
-                    CGDKButton("顯示 Toast") { toast.show("已儲存") }
-                    CGDKButton("Danger", style: .danger) {}
-                    CGDKButton("Ghost", style: .ghost) {}
                 }
-                .padding(CGDKTokens.Space.xl)
+                CGDKButton("顯示 Toast") { toast.show("已儲存") }
+                CGDKButton("Danger", style: .danger) {}
+                CGDKButton("Ghost", style: .ghost) {}
             }
-            .environmentObject(theme)
-            .cgdkThemedBackground()
-            .cgdkAppStyle()
+            .padding(CGDKTokens.Space.xl)
         }
     }
 }
 
 #Preview("Demo") {
     CGDKDemoView()
-        .environmentObject(CGDKThemeManager())   // ← 必加
 }


### PR DESCRIPTION
## Summary
- create `CGDKRoot` view to apply theme, toast host, and standard styling
- update demo preview to use `CGDKRoot`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project ChiuGaDevKit.xcodeproj -scheme ChiuGaDevKit -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a53a5bf294832bac8d5a7829456557